### PR TITLE
fix: 修复 macOS 端搜索结果部分歌曲无法播放的三类问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ search-history.json
 ai-config.json
 .vs/
 
+# webstorm工程文件
+.idea
+
 # 依赖与杂项
 node_modules/
 .DS_Store

--- a/src-tauri/src/guest_playurl.rs
+++ b/src-tauri/src/guest_playurl.rs
@@ -108,27 +108,26 @@ impl GuestPlayurlClient {
         ensure_not_cancelled(cancellation)?;
 
         // DASH 音频轨优先；新投稿可能只有 durl 混合流，作为兜底。
-        let (audio_url, muxed_preview) =
-            match select_audio(playurl.data.as_ref()) {
-                Ok(audio) => {
-                    let audio_url = first_working_audio_url(&self.client, audio).await?;
-                    (audio_url.to_owned(), false)
-                }
-                Err(audio_error) => {
-                    let durl = select_muxed_durl(playurl.data.as_ref());
-                    match durl {
-                        Ok(durl) => {
-                            let url = first_working_muxed_url(&self.client, durl).await?;
-                            (url, true)
-                        }
-                        Err(durl_error) => {
-                            return Err(format!(
-                                "{audio_error}; durl fallback unavailable: {durl_error}"
-                            ));
-                        }
+        let (audio_url, muxed_preview) = match select_audio(playurl.data.as_ref()) {
+            Ok(audio) => {
+                let audio_url = first_working_audio_url(&self.client, audio).await?;
+                (audio_url.to_owned(), false)
+            }
+            Err(audio_error) => {
+                let durl = select_muxed_durl(playurl.data.as_ref());
+                match durl {
+                    Ok(durl) => {
+                        let url = first_working_muxed_url(&self.client, durl).await?;
+                        (url, true)
+                    }
+                    Err(durl_error) => {
+                        return Err(format!(
+                            "{audio_error}; durl fallback unavailable: {durl_error}"
+                        ));
                     }
                 }
-            };
+            }
+        };
         ensure_not_cancelled(cancellation)?;
 
         let title = page_hint
@@ -604,7 +603,13 @@ fn select_audio(data: Option<&PlayurlData>) -> Result<&AudioStream, String> {
 /// `<audio>` 元素只出音轨，但老视频可能是 FLV 容器，需要 probe 后验证 MP4 签名。
 fn select_muxed_durl(data: Option<&PlayurlData>) -> Result<&DurlStream, String> {
     let durl = data
-        .and_then(|data| if data.durl.is_empty() { None } else { Some(&data.durl) })
+        .and_then(|data| {
+            if data.durl.is_empty() {
+                None
+            } else {
+                Some(&data.durl)
+            }
+        })
         .ok_or_else(|| "Bilibili playurl response has no data.durl".to_owned())?;
     Ok(&durl[0])
 }
@@ -953,7 +958,10 @@ mod tests {
                 base_url_camel: None,
                 base_url_snake: Some("https://upos.example.bilivideo.com/m.mp4".to_owned()),
                 url: None,
-                backup_url_camel: vec!["".to_owned(), "https://backup.example.bilivideo.com/b.mp4".to_owned()],
+                backup_url_camel: vec![
+                    "".to_owned(),
+                    "https://backup.example.bilivideo.com/b.mp4".to_owned(),
+                ],
                 backup_url_snake: vec![],
             }],
         };

--- a/src-tauri/src/guest_playurl.rs
+++ b/src-tauri/src/guest_playurl.rs
@@ -107,8 +107,28 @@ impl GuestPlayurlClient {
             fetch_playurl(&self.client, bvid, target_cid, &cookie_header, &mixin_key).await?;
         ensure_not_cancelled(cancellation)?;
 
-        let audio = select_audio(playurl.data.as_ref())?;
-        let audio_url = first_working_audio_url(&self.client, audio).await?;
+        // DASH 音频轨优先；新投稿可能只有 durl 混合流，作为兜底。
+        let (audio_url, muxed_preview) =
+            match select_audio(playurl.data.as_ref()) {
+                Ok(audio) => {
+                    let audio_url = first_working_audio_url(&self.client, audio).await?;
+                    (audio_url.to_owned(), false)
+                }
+                Err(audio_error) => {
+                    let durl = select_muxed_durl(playurl.data.as_ref());
+                    match durl {
+                        Ok(durl) => {
+                            let url = first_working_muxed_url(&self.client, durl).await?;
+                            (url, true)
+                        }
+                        Err(durl_error) => {
+                            return Err(format!(
+                                "{audio_error}; durl fallback unavailable: {durl_error}"
+                            ));
+                        }
+                    }
+                }
+            };
         ensure_not_cancelled(cancellation)?;
 
         let title = page_hint
@@ -124,11 +144,12 @@ impl GuestPlayurlClient {
             .unwrap_or(view.duration_seconds);
 
         Ok(StreamAudioInfo {
-            audio_url: audio_url.to_owned(),
+            audio_url,
             title,
             uploader: view.uploader,
             thumbnail_url: normalize_url(&view.thumbnail_url),
             duration_seconds: duration_seconds as f64,
+            muxed_preview,
         })
     }
 
@@ -229,7 +250,7 @@ async fn first_working_audio_url<'a>(
     client: &reqwest::Client,
     audio: &'a AudioStream,
 ) -> Result<&'a str, String> {
-    let candidates = audio.url_candidates();
+    let candidates = ordered_candidates(audio);
     if candidates.is_empty() {
         return Err(format!(
             "selected audio id {} has no baseUrl/base_url or backup URLs",
@@ -247,6 +268,35 @@ async fn first_working_audio_url<'a>(
     Err(format!(
         "all audio URLs for id {} failed probe: {}",
         audio.id,
+        last_error.unwrap_or_else(|| "unknown probe failure".to_owned())
+    ))
+}
+
+/// durl 兜底专用：逐个候选 probe，且必须验证 MP4 签名（ftyp），
+/// 老 FLV durl 交给 `<audio>` 播不了，宁可失败走现有跳过逻辑。
+async fn first_working_muxed_url(
+    client: &reqwest::Client,
+    durl: &DurlStream,
+) -> Result<String, String> {
+    let candidates = durl.url_candidates();
+    if candidates.is_empty() {
+        return Err("durl entry has no baseUrl/url".to_owned());
+    }
+
+    let mut last_error = None;
+    for candidate in candidates {
+        match probe_audio_url(client, candidate).await {
+            Ok(probe) => {
+                if probe.looks_mp4() {
+                    return Ok(normalize_url(candidate));
+                }
+                last_error = Some("durl stream is not MP4 (unsupported container)".to_owned());
+            }
+            Err(error) => last_error = Some(error),
+        }
+    }
+    Err(format!(
+        "all durl URLs failed probe: {}",
         last_error.unwrap_or_else(|| "unknown probe failure".to_owned())
     ))
 }
@@ -550,6 +600,36 @@ fn select_audio(data: Option<&PlayurlData>) -> Result<&AudioStream, String> {
         })
 }
 
+/// 新投稿兜底：DASH 音频轨缺失时，回退到 durl 混合流（音视频合一的渐进式 mp4）。
+/// `<audio>` 元素只出音轨，但老视频可能是 FLV 容器，需要 probe 后验证 MP4 签名。
+fn select_muxed_durl(data: Option<&PlayurlData>) -> Result<&DurlStream, String> {
+    let durl = data
+        .and_then(|data| if data.durl.is_empty() { None } else { Some(&data.durl) })
+        .ok_or_else(|| "Bilibili playurl response has no data.durl".to_owned())?;
+    Ok(&durl[0])
+}
+
+/// mcdn 边缘节点（P2P 风格 CDN 池）存活时间极短：探测时可能存活、
+/// 播放器真正取流时已 404。因此稳定镜像优先，mcdn 仅作无替代时的兑底。
+fn is_volatile_mcdn_host(url: &str) -> bool {
+    url.split_once("//")
+        .and_then(|(_, rest)| rest.split('/').next())
+        .map(|host| {
+            let host = host.split('@').next().unwrap_or(host);
+            host.contains("mcdn.")
+        })
+        .unwrap_or(false)
+}
+
+/// 候选重排：稳定镜像保序在前，mcdn 节点沉到末尾（组内保序）。
+fn ordered_candidates(audio: &AudioStream) -> Vec<&str> {
+    let (stable, volatile): (Vec<&str>, Vec<&str>) = audio
+        .url_candidates()
+        .into_iter()
+        .partition(|url| !is_volatile_mcdn_host(url));
+    stable.into_iter().chain(volatile).collect()
+}
+
 async fn probe_audio_url(client: &reqwest::Client, audio_url: &str) -> Result<ProbeResult, String> {
     let response = client
         .get(audio_url)
@@ -567,14 +647,14 @@ async fn probe_audio_url(client: &reqwest::Client, audio_url: &str) -> Result<Pr
     let bytes = response
         .bytes()
         .await
-        .map_err(|error| format!("failed to read audio probe bytes: {error}"))?
-        .len();
-    if bytes == 0 {
+        .map_err(|error| format!("failed to read audio probe bytes: {error}"))?;
+    if bytes.is_empty() {
         return Err("audio URL probe returned zero bytes".to_owned());
     }
     Ok(ProbeResult {
         status: status.as_u16(),
-        bytes,
+        bytes: bytes.len(),
+        head: bytes[..bytes.len().min(16)].to_vec(),
     })
 }
 
@@ -628,6 +708,14 @@ fn unix_timestamp() -> u64 {
 struct ProbeResult {
     status: u16,
     bytes: usize,
+    head: Vec<u8>,
+}
+
+impl ProbeResult {
+    /// MP4 文件在偏移 4~8 字节处有 "ftyp" 盒类型标识。
+    fn looks_mp4(&self) -> bool {
+        self.head.len() >= 8 && &self.head[4..8] == b"ftyp"
+    }
 }
 
 #[derive(Deserialize)]
@@ -696,6 +784,47 @@ struct PlayurlEnvelope {
 #[derive(Deserialize)]
 struct PlayurlData {
     dash: Option<DashData>,
+    /// 新投稿在音频轨转码完成前，playurl 可能只返回 durl（音视频混合流）。
+    #[serde(default)]
+    durl: Vec<DurlStream>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DurlStream {
+    #[serde(default, rename = "baseUrl")]
+    base_url_camel: Option<String>,
+    #[serde(default, rename = "base_url")]
+    base_url_snake: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default, rename = "backupUrl")]
+    backup_url_camel: Vec<String>,
+    #[serde(default, rename = "backup_url")]
+    backup_url_snake: Vec<String>,
+}
+
+impl DurlStream {
+    fn url_candidates(&self) -> Vec<&str> {
+        let mut candidates = Vec::new();
+        if let Some(url) = self
+            .base_url_camel
+            .as_deref()
+            .or(self.base_url_snake.as_deref())
+            .or(self.url.as_deref())
+        {
+            if !url.trim().is_empty() {
+                candidates.push(url);
+            }
+        }
+        candidates.extend(
+            self.backup_url_camel
+                .iter()
+                .chain(self.backup_url_snake.iter())
+                .map(String::as_str)
+                .filter(|url| !url.trim().is_empty()),
+        );
+        candidates
+    }
 }
 
 #[derive(Deserialize)]
@@ -764,7 +893,10 @@ impl AudioStream {
 
 #[cfg(test)]
 mod tests {
-    use super::{select_audio, AudioStream, DashData, PlayurlData};
+    use super::{
+        ordered_candidates, select_audio, select_muxed_durl, AudioStream, DashData, DurlStream,
+        PlayurlData, ProbeResult,
+    };
 
     #[test]
     fn prefers_medium_aac_then_low_aac() {
@@ -792,6 +924,7 @@ mod tests {
             dash: Some(DashData {
                 audio: vec![low, medium],
             }),
+            durl: vec![],
         };
 
         assert_eq!(select_audio(Some(&data)).unwrap().id, 30232);
@@ -801,6 +934,7 @@ mod tests {
     fn rejects_missing_audio_streams_clearly() {
         let data = PlayurlData {
             dash: Some(DashData { audio: vec![] }),
+            durl: vec![],
         };
 
         assert!(select_audio(Some(&data))
@@ -809,5 +943,114 @@ mod tests {
         assert!(select_audio(None)
             .unwrap_err()
             .contains("no data.dash.audio"));
+    }
+
+    #[test]
+    fn falls_back_to_durl_only_for_fresh_uploads() {
+        let data = PlayurlData {
+            dash: None,
+            durl: vec![DurlStream {
+                base_url_camel: None,
+                base_url_snake: Some("https://upos.example.bilivideo.com/m.mp4".to_owned()),
+                url: None,
+                backup_url_camel: vec!["".to_owned(), "https://backup.example.bilivideo.com/b.mp4".to_owned()],
+                backup_url_snake: vec![],
+            }],
+        };
+
+        assert!(select_audio(Some(&data)).is_err());
+        let candidates = select_muxed_durl(Some(&data)).unwrap().url_candidates();
+        assert_eq!(
+            candidates,
+            vec![
+                "https://upos.example.bilivideo.com/m.mp4",
+                "https://backup.example.bilivideo.com/b.mp4",
+            ]
+        );
+    }
+
+    #[test]
+    fn durl_fallback_reports_missing_durl_clearly() {
+        let data = PlayurlData {
+            dash: Some(DashData { audio: vec![] }),
+            durl: vec![],
+        };
+
+        let error = select_muxed_durl(Some(&data)).unwrap_err();
+        assert!(error.contains("no data.durl"));
+    }
+
+    #[test]
+    fn probe_head_detects_mp4_signature() {
+        let mp4 = ProbeResult {
+            status: 206,
+            bytes: 4096,
+            head: vec![0, 0, 0, 24, b'f', b't', b'y', b'p', b'i', b's', b'o', b'm'],
+        };
+        assert!(mp4.looks_mp4());
+
+        let flv = ProbeResult {
+            status: 206,
+            bytes: 4096,
+            head: vec![b'F', b'L', b'V', 1, 5, 0, 0, 0, 9],
+        };
+        assert!(!flv.looks_mp4());
+
+        let short = ProbeResult {
+            status: 206,
+            bytes: 4,
+            head: vec![0, 0, 0, 24],
+        };
+        assert!(!short.looks_mp4());
+    }
+
+    #[test]
+    fn candidates_prefer_stable_mirrors_over_mcdn() {
+        let audio = audio_stream(vec![
+            "https://xy113x207x85x153xy.mcdn.bilivideo.cn:8082/base.mp4",
+            "https://upos-sz-mirrorcos.bilivideo.com/backup1.mp4",
+            "https://cn-sccd-ct-02-11.bilivideo.com/backup2.mp4",
+            "https://xy116x196x140x19xy.mcdn.bilivideo.cn/base3.mp4",
+        ]);
+
+        assert_eq!(
+            ordered_candidates(&audio),
+            vec![
+                "https://upos-sz-mirrorcos.bilivideo.com/backup1.mp4",
+                "https://cn-sccd-ct-02-11.bilivideo.com/backup2.mp4",
+                "https://xy113x207x85x153xy.mcdn.bilivideo.cn:8082/base.mp4",
+                "https://xy116x196x140x19xy.mcdn.bilivideo.cn/base3.mp4",
+            ]
+        );
+    }
+
+    #[test]
+    fn all_mcdn_candidates_still_usable_in_original_order() {
+        let audio = audio_stream(vec![
+            "https://xy1x1x1x1xy.mcdn.bilivideo.cn/a.mp4",
+            "https://xy2x2x2x2xy.mcdn.bilivideo.cn/b.mp4",
+        ]);
+
+        assert_eq!(
+            ordered_candidates(&audio),
+            vec![
+                "https://xy1x1x1x1xy.mcdn.bilivideo.cn/a.mp4",
+                "https://xy2x2x2x2xy.mcdn.bilivideo.cn/b.mp4",
+            ]
+        );
+    }
+
+    fn audio_stream(urls: Vec<&str>) -> AudioStream {
+        let mut iter = urls.into_iter();
+        AudioStream {
+            id: 30232,
+            base_url_camel: iter.next().map(str::to_owned),
+            base_url_snake: None,
+            backup_url_camel: iter.map(str::to_owned).collect(),
+            backup_url_snake: vec![],
+            codecs: Some("mp4a.40.2".to_owned()),
+            mime_type_camel: Some("audio/mp4".to_owned()),
+            mime_type_snake: None,
+        }
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -184,6 +184,10 @@ async fn prepare_audio(
             duration_seconds: duration_seconds.map(|value| value.max(0.0).round() as u64),
         };
         let source = *state.stream_source.read().await;
+        eprintln!(
+            "[prepare_audio] begin {bv_id} cid={cid:?} source={}",
+            source.as_str()
+        );
         let info = match source {
             StreamSource::Auto => {
                 match state
@@ -239,6 +243,12 @@ async fn prepare_audio(
             }
         };
 
+        if info.muxed_preview {
+            eprintln!(
+                "[prepare_audio] {bv_id}: no DASH audio for guest (fresh upload?), using muxed durl stream"
+            );
+        }
+
         if !state.resolver.is_current(job_id) {
             return Err(AUDIO_RESOLUTION_CANCELLED.to_owned());
         }
@@ -247,6 +257,7 @@ async fn prepare_audio(
             format!("{} returned an invalid audio URL: {error}", source.as_str())
         })?;
         validate_cdn_url(&upstream_url)?;
+        let upstream_host = upstream_url.host_str().unwrap_or("?").to_owned();
 
         let token = Uuid::new_v4().simple().to_string();
         let now = Instant::now();
@@ -269,6 +280,10 @@ async fn prepare_audio(
             .strip_prefix("http://")
             .map(|url| format!("https://{url}"))
             .unwrap_or(info.thumbnail_url);
+        eprintln!(
+            "[prepare_audio] resolved {bv_id} muxed={} host={upstream_host}",
+            info.muxed_preview
+        );
 
         Ok(AudioResponse {
             audio_url: format!("{}/audio/{token}", state.proxy_base_url),
@@ -506,6 +521,7 @@ async fn proxy_audio(
         return empty_response(StatusCode::GONE);
     }
 
+    let upstream_host = entry.url.host_str().unwrap_or("?").to_owned();
     let mut upstream_request = state
         .client
         .request(method.clone(), entry.url)
@@ -517,10 +533,19 @@ async fn proxy_audio(
 
     let upstream = match upstream_request.send().await {
         Ok(response) => response,
-        Err(_) => return empty_response(StatusCode::BAD_GATEWAY),
+        Err(error) => {
+            eprintln!("[audio-proxy] upstream request failed: {error}");
+            return empty_response(StatusCode::BAD_GATEWAY);
+        }
     };
 
     let status = upstream.status();
+    if !(status.is_success() || status.as_u16() == 206) {
+        eprintln!(
+            "[audio-proxy] upstream returned HTTP {} for {}",
+            status.as_u16(), upstream_host
+        );
+    }
     let mut response = Response::builder()
         .status(status)
         .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
@@ -530,7 +555,6 @@ async fn proxy_audio(
             "Accept-Ranges, Content-Length, Content-Range, Content-Type, ETag, Last-Modified",
         );
     for name in [
-        CONTENT_TYPE,
         CONTENT_LENGTH,
         CONTENT_RANGE,
         ETAG,
@@ -541,6 +565,30 @@ async fn proxy_audio(
             response = response.header(name, value);
         }
     }
+
+    // 部分B站CDN节点对音轨返回 application/octet-stream；macOS WKWebView
+    // 拒绝把该类型当作媒体解码（表现为时间停在0、无进度）。本代理只服务
+    // B站音频流（MP4 容器），遇到八进制流或缺失类型时改写为 audio/mp4。
+    let upstream_content_type = upstream
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .unwrap_or("");
+    let normalized_content_type = if upstream_content_type.is_empty()
+        || upstream_content_type.eq_ignore_ascii_case("application/octet-stream")
+    {
+        if !upstream_content_type.is_empty() {
+            eprintln!(
+                "[audio-proxy] normalized content-type '{}' to audio/mp4 for {upstream_host}",
+                upstream_content_type
+            );
+        }
+        "audio/mp4"
+    } else {
+        upstream_content_type
+    };
+    response = response.header(CONTENT_TYPE, normalized_content_type);
 
     let body = if method == Method::HEAD {
         Body::empty()

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -543,7 +543,8 @@ async fn proxy_audio(
     if !(status.is_success() || status.as_u16() == 206) {
         eprintln!(
             "[audio-proxy] upstream returned HTTP {} for {}",
-            status.as_u16(), upstream_host
+            status.as_u16(),
+            upstream_host
         );
     }
     let mut response = Response::builder()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,8 @@ pub struct StreamAudioInfo {
     pub uploader: String,
     pub thumbnail_url: String,
     pub duration_seconds: f64,
+    /// 新投稿 DASH 音轨未转码时的 durl 混合流兜底标记；仅供日志与诊断，不参与逻辑分支。
+    pub muxed_preview: bool,
 }
 
 #[derive(Debug)]
@@ -322,6 +324,7 @@ pub fn resolve_bilibili_audio_cancellable_with_page(
         uploader: parsed.uploader,
         thumbnail_url: parsed.thumbnail_url,
         duration_seconds: parsed.duration_seconds,
+        muxed_preview: false,
     })
 }
 

--- a/ui/main.js
+++ b/ui/main.js
@@ -2543,7 +2543,7 @@ async function loadCurrentTrack({
     }
 
     if (advancePageWithinCurrentBv({ automatic: true, skipFailed: true })) {
-      showPlaybackNotice("璇ュ垎 P 鏃犳硶鎾斁锛屽凡鑷姩璺宠繃銆?");
+      showPlaybackNotice("该分P无法播放，已自动跳过。");
       return;
     }
 


### PR DESCRIPTION
## 问题

macOS 实际使用中发现：搜索结果中部分歌曲点击后无法播放，表现为播放条时间停在 0、无进度、无提示（或触发自动跳过），且时好时坏。

## 排查与根因（全部实测复现）

在 macOS（WKWebView）环境逐一定位出**三个相互独立**的根因：

### 1. 新投稿视频无 DASH 音频轨
发布数小时内的视频，playurl 接口（含 WBI 签名链路）只返回 `durl`（音视频合一的渐进式 mp4），不存在 `data.dash.audio`，原逻辑直接解析失败。参数调整（fnval/platform/try_look）均无效。

### 2. mcdn 边缘节点漂移
B 站将部分视频的音频 `baseUrl` 指向 `*.mcdn.bilivideo.cn`（P2P 风格节点池，存活时间极短）。原逻辑按顺序探测、首个通过即用——mcdn 探测瞬间存活即被选中，稳定的 `backupUrl` 镜像从未尝试；播放器经代理真正取流时节点已 404，且代理失败静默无日志。实测同一首歌连 resolve 6 次全部命中 mcdn，随后该 URL 连续 5 次 404。

### 3. octet-stream 媒体类型（macOS 独有）
部分 CDN 节点（如 `upos-sz-estgcos`）对音轨返回 `Content-Type: application/octet-stream`，代理原样透传后，**WKWebView 拒绝把该类型当媒体解码**（内容本身是合法 MP4）。Windows WebView2/Chromium 会嗅探字节流照常播放，故此问题仅 macOS 出现。

## 修复

1. **durl 兜底**：`code=0` 但无 `dash.audio` 且存在 `durl` 时，逐候选 probe 并校验 MP4 签名（`ftyp`）后作为音频源；FLV 等不支持容器仍走现有跳过逻辑。`<audio>` 元素只出音轨。
2. **候选分级**：稳定镜像（`bilivideo.com` 等）保序优先探测，mcdn 主机沉到末尾仅在无替代时兜底。
3. **Content-Type 归一化**：代理将 `application/octet-stream` 或缺失类型改写为 `audio/mp4`，其余原样透传。代理路由、Range 透传、token 机制未改动。

附带改进：
- `StreamAudioInfo` 增加 `muxed_preview` 标记（仅日志诊断，不参与逻辑分支）；
- `prepare_audio` 增加入口/成功日志，代理上游失败不再静默（只打 host 与状态码，不输出带签名的完整 URL）；
- 修复“该分P无法播放”提示文案乱码。

## 验证

- Rust 单测 **35/35**（新增 6 个：durl 兜底选择、durl 候选提取、缺失报错、ftyp 判定、稳定镜像优先排序、全 mcdn 保序）；
- 前端 node:test **25/25**；
- macOS 实测：新投稿 durl 视频、mcdn 类视频、octet-stream 类视频均恢复正常播放；连 resolve 6 次全部稳定选中 `bilivideo.com` 镜像；普通视频 / 切歌 / 自动连播行为无变化；
- Windows 行为无变化（未改动 WebView 差异路径以外的任何共享逻辑）。

## 已知权衡

- 新投稿 durl 兜底期间会连视频轨一起拉流（360p 约 340kbps），转码完成后自动恢复纯音轨 DASH；
- 多段 durl 仅取第一段（当前观察 B 站音频 durl 均为单段）；
- 播放中途 CDN 节点死亡（非首帧失败）仍需重新点歌换流，未在本次范围内处理。