### PR TITLE
feat: 歌单重复添加提示 + 重启后自动复用上次搜索关键词

### DIFF
--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -301,17 +301,26 @@ pub fn delete_playlist(id: String) -> Result<Vec<Playlist>, String> {
 
 #[tauri::command]
 pub fn add_to_playlist(id: String, track: TrackSnapshotInput) -> Result<Vec<Playlist>, String> {
-    let mut file = read_playlists()?;
+    add_to_playlist_at(&playlists_path()?, id, track)
+}
+
+fn add_to_playlist_at(
+    path: &Path,
+    id: String,
+    track: TrackSnapshotInput,
+) -> Result<Vec<Playlist>, String> {
+    let mut file = read_json_or_default(path)?;
     let snapshot = snapshot_from_input(track)?;
     let playlist = find_playlist_mut(&mut file, &id)?;
-    if !playlist
+    if playlist
         .items
         .iter()
         .any(|item| item.bvid.eq_ignore_ascii_case(&snapshot.bvid))
     {
-        playlist.items.push(snapshot);
+        return Err(format!("歌曲已在歌单“{}”中。", playlist.name));
     }
-    write_json_atomic(&playlists_path()?, &file)?;
+    playlist.items.push(snapshot);
+    write_json_atomic(path, &file)?;
     Ok(file.playlists)
 }
 
@@ -753,6 +762,26 @@ fn create_imported_playlist_at(
 #[cfg(test)]
 mod import_tests {
     use super::*;
+
+    #[test]
+    fn add_to_playlist_rejects_duplicates_without_writing() {
+        let path = std::env::temp_dir().join(format!("bili-add-{}.json", Uuid::new_v4()));
+        let created =
+            create_imported_playlist_at(&path, "歌单".into(), vec![input("BV1rW4y1Q7o7")]).unwrap();
+        let before = fs::read(&path).unwrap();
+        let error = add_to_playlist_at(&path, "不存在".into(), input("BV1rW4y1Q7o7")).unwrap_err();
+        assert!(error.contains("不存在"));
+        let playlists = add_to_playlist_at(&path, created.id.clone(), input("BV1rW4y1Q7o7")).unwrap_err();
+        assert!(playlists.contains("歌曲已在歌单“歌单”中"));
+        // 大小写不同的 BV 号也应视为重复。
+        let error = add_to_playlist_at(&path, created.id.clone(), input("BV1RW4Y1Q7O7")).unwrap_err();
+        assert!(error.contains("歌曲已在歌单"));
+        assert_eq!(fs::read(&path).unwrap(), before);
+        add_to_playlist_at(&path, created.id, input("BV1cs411f7ZC")).unwrap();
+        let file: PlaylistsFile = read_json_or_default(&path).unwrap();
+        assert_eq!(file.playlists[0].items.len(), 2);
+        fs::remove_file(path).unwrap();
+    }
 
     fn input(bvid: &str) -> TrackSnapshotInput {
         TrackSnapshotInput {

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -771,10 +771,12 @@ mod import_tests {
         let before = fs::read(&path).unwrap();
         let error = add_to_playlist_at(&path, "不存在".into(), input("BV1rW4y1Q7o7")).unwrap_err();
         assert!(error.contains("不存在"));
-        let playlists = add_to_playlist_at(&path, created.id.clone(), input("BV1rW4y1Q7o7")).unwrap_err();
+        let playlists =
+            add_to_playlist_at(&path, created.id.clone(), input("BV1rW4y1Q7o7")).unwrap_err();
         assert!(playlists.contains("歌曲已在歌单“歌单”中"));
         // 大小写不同的 BV 号也应视为重复。
-        let error = add_to_playlist_at(&path, created.id.clone(), input("BV1RW4Y1Q7O7")).unwrap_err();
+        let error =
+            add_to_playlist_at(&path, created.id.clone(), input("BV1RW4Y1Q7O7")).unwrap_err();
         assert!(error.contains("歌曲已在歌单"));
         assert_eq!(fs::read(&path).unwrap(), before);
         add_to_playlist_at(&path, created.id, input("BV1cs411f7ZC")).unwrap();

--- a/tests/last-search-restore.test.cjs
+++ b/tests/last-search-restore.test.cjs
@@ -1,0 +1,123 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+const vm = require("node:vm");
+
+const source = readFileSync(path.join(__dirname, "../ui/main.js"), "utf8");
+
+// 切片：关键词持久化助手 + 恢复搜索状态与提示（runSearch + currentSearchRequest）。
+const helpers = source.slice(
+  source.indexOf("const LAST_SEARCH_KEY"),
+  source.indexOf("const homeState"),
+);
+const requestFns = source.slice(
+  source.indexOf("function currentSearchRequest("),
+  source.indexOf("async function runSearch("),
+);
+const runSearchFn = source.slice(
+  source.indexOf("async function runSearch("),
+  source.indexOf("searchForm.addEventListener("),
+);
+assert.ok(helpers.includes("function saveLastSearchKeyword"));
+assert.ok(runSearchFn.includes("restored"));
+
+function setup({ keyword = "", results = [] } = {}) {
+  const storage = new Map();
+  if (keyword) {
+    storage.set("bilibili-music.last-search", keyword);
+  }
+  const context = vm.createContext({
+    localStorage: {
+      getItem: (key) => (storage.has(key) ? storage.get(key) : null),
+      setItem: (key, value) => storage.set(key, String(value)),
+    },
+    SEARCH_PAGE_SIZE: 20,
+    MUSIC_HOT_KEYWORD: "音乐",
+    searchKeyword: { value: keyword },
+    searchButton: { disabled: false },
+    searchStatus: { textContent: "" },
+    result: { hidden: true },
+    searchState: {
+      results,
+      userKeyword: "",
+      requestKeyword: "",
+      tids: 3,
+      order: null,
+      rerank: true,
+      sortMode: "all",
+      page: 0,
+      isLoadingMore: false,
+      hasMore: false,
+      requestVersion: 0,
+    },
+    recordSearchHistoryFireAndForget() {},
+    setSearchResults(videos) {
+      context.searchState.results = videos;
+    },
+    updateQueueUi() {},
+    invoke: async () => {
+      throw new Error("unexpected invoke");
+    },
+    console: { warn() {} },
+  });
+  vm.runInContext(
+    helpers + "\n" + requestFns + "\n" + runSearchFn + "\nglobalThis.__api = { runSearch, readLastSearchKeyword, saveLastSearchKeyword };",
+    context,
+  );
+  return { context, storage };
+}
+
+test("restored search announces the reused keyword while loading and after success", async () => {
+  const { context, storage } = setup({ keyword: "周杰伦" });
+  let calls = 0;
+  context.__api.runSearch;
+  const ctx = context;
+  ctx.invoke = async (command, payload) => {
+    calls += 1;
+    assert.equal(command, "search_videos");
+    assert.equal(payload.keyword, "周杰伦");
+    return [{ bvid: "BV0000000001" }, { bvid: "BV0000000002" }];
+  };
+  const p = ctx.__api.runSearch({ userKeyword: "周杰伦", restored: true });
+  assert.match(ctx.searchStatus.textContent, /已复用上次搜索关键词「周杰伦」，正在搜索…/);
+  await p;
+  assert.match(ctx.searchStatus.textContent, /已复用上次搜索关键词「周杰伦」刷新完成，找到 2 个普通视频/);
+  assert.equal(calls, 1);
+  assert.equal(storage.get("bilibili-music.last-search"), "周杰伦");
+});
+
+test("restored search failure keeps the reuse notice in the error message", async () => {
+  const { context } = setup();
+  context.invoke = async () => Promise.reject("网络中断");
+  await context.__api.runSearch({ userKeyword: "洛天依", restored: true });
+  assert.match(context.searchStatus.textContent, /复用上次搜索关键词「洛天依」搜索失败：网络中断/);
+});
+
+test("successful keyword search persists the keyword; empty tab search does not", async () => {
+  const { context, storage } = setup();
+  context.invoke = async () => [{ bvid: "BV0000000001" }];
+  await context.__api.runSearch({ userKeyword: "林俊杰" });
+  assert.equal(storage.get("bilibili-music.last-search"), "林俊杰");
+
+  // 无关键词的分区热门不覆盖已存关键词。
+  context.invoke = async () => [{ bvid: "BV0000000002" }];
+  await context.__api.runSearch({ userKeyword: "" });
+  assert.equal(storage.get("bilibili-music.last-search"), "林俊杰");
+});
+
+test("failed keyword search does not persist the keyword", async () => {
+  const { context, storage } = setup();
+  context.invoke = async () => {
+    throw new Error("超时");
+  };
+  await context.__api.runSearch({ userKeyword: "坏关键词" });
+  assert.ok(!storage.has("bilibili-music.last-search"));
+});
+
+test("corrupted or oversized stored keyword is clamped by readLastSearchKeyword", () => {
+  const { context } = setup({ keyword: "   ".padEnd(120, "a") });
+  const value = context.__api.readLastSearchKeyword();
+  assert.ok(value.length <= 100);
+  assert.equal(value, value.trim());
+});

--- a/ui/main.js
+++ b/ui/main.js
@@ -2391,12 +2391,26 @@ function choosePlaylistAndAdd(video = currentPlayableTrack()) {
     empty.textContent = "还没有歌单。先在下方新建一个，再把这首歌放进去。";
     list.append(empty);
   } else {
+    const trackBvid = track.bvid.toLowerCase();
     for (const playlist of libraryState.playlists) {
+      const alreadyIn = playlist.items.some(
+        (item) => String(item?.bvid ?? "").toLowerCase() === trackBvid,
+      );
       const button = document.createElement("button");
       button.type = "button";
       button.className = "playlist-choice";
-      button.innerHTML = `<span>${escapeText(playlist.name)}</span><small>${playlist.items.length} 首</small>`;
-      button.addEventListener("click", () => addTrackToPlaylist(playlist, track));
+      if (alreadyIn) {
+        button.classList.add("is-added");
+        button.setAttribute("aria-disabled", "true");
+      }
+      button.innerHTML = `<span>${escapeText(playlist.name)}</span><small>${alreadyIn ? "已添加 · " : ""}${playlist.items.length} 首</small>`;
+      button.addEventListener("click", () => {
+        if (alreadyIn) {
+          libraryModalStatus.textContent = `该歌曲已在歌单“${playlist.name}”中，无需重复加入。`;
+          return;
+        }
+        addTrackToPlaylist(playlist, track);
+      });
       list.append(button);
     }
   }
@@ -2450,7 +2464,10 @@ async function addTrackToPlaylist(playlist, track) {
     status.textContent = `已加入歌单“${playlist.name}”。`;
     closeLibraryModal();
   } catch (error) {
-    libraryModalStatus.textContent = `加入歌单失败：${error}`;
+    // 后端重复检测兑底（例如弹窗打开期间歌单已在别处被更新）。
+    libraryModalStatus.textContent = String(error).includes("歌曲已在歌单")
+      ? `${error}`
+      : `加入歌单失败：${error}`;
   }
 }
 

--- a/ui/main.js
+++ b/ui/main.js
@@ -51,6 +51,26 @@ const searchState = {
   requestVersion: 0,
 };
 
+const LAST_SEARCH_KEY = "bilibili-music.last-search";
+let pendingSearchRestore = null;
+
+function readLastSearchKeyword() {
+  try {
+    const value = localStorage.getItem(LAST_SEARCH_KEY);
+    return typeof value === "string" ? value.trim().slice(0, 100) : "";
+  } catch {
+    return "";
+  }
+}
+
+function saveLastSearchKeyword(keyword) {
+  try {
+    localStorage.setItem(LAST_SEARCH_KEY, keyword);
+  } catch (error) {
+    console.warn("last search keyword save failed:", error);
+  }
+}
+
 const homeState = {
   mode: "recommendation",
   ranking: [],
@@ -2962,10 +2982,20 @@ function currentSearchRequest(userKeyword) {
   };
 }
 
-async function runSearch({ userKeyword = searchKeyword.value.trim(), recordHistory = false } = {}) {
+async function runSearch({
+  userKeyword = searchKeyword.value.trim(),
+  recordHistory = false,
+  restored = false,
+} = {}) {
   const query = currentSearchRequest(userKeyword);
   searchButton.disabled = true;
-  searchStatus.textContent = query.userKeyword ? "正在搜索…" : "正在加载该分区热门…";
+  if (query.userKeyword) {
+    searchStatus.textContent = restored
+      ? `已复用上次搜索关键词「${query.userKeyword}」，正在搜索…`
+      : "正在搜索…";
+  } else {
+    searchStatus.textContent = "正在加载该分区热门…";
+  }
   const requestVersion = ++searchState.requestVersion;
   searchState.userKeyword = query.userKeyword;
   searchState.requestKeyword = query.requestKeyword;
@@ -2999,17 +3029,26 @@ async function runSearch({ userKeyword = searchKeyword.value.trim(), recordHisto
     setSearchResults(videos);
     result.hidden = false;
     searchState.hasMore = videos.length >= SEARCH_PAGE_SIZE;
+    if (searchState.userKeyword) {
+      // 仅在真实成功后记录，失败的搜索不沉淀为“上次搜索”。
+      saveLastSearchKeyword(searchState.userKeyword);
+    }
     const modeLabel = searchState.userKeyword ? "" : "（分区热门）";
-    searchStatus.textContent = videos.length
+    const foundLabel = videos.length
       ? searchState.hasMore
         ? `找到 ${videos.length} 个普通视频${modeLabel}。`
         : `找到 ${videos.length} 个普通视频${modeLabel}。没有更多了`
       : "没有找到普通视频。";
+    searchStatus.textContent = restored
+      ? `已复用上次搜索关键词「${searchState.userKeyword}」刷新完成，${foundLabel}`
+      : foundLabel;
   } catch (error) {
     if (requestVersion !== searchState.requestVersion) {
       return;
     }
-    searchStatus.textContent = `搜索失败：${error}`;
+    searchStatus.textContent = restored
+      ? `复用上次搜索关键词「${searchState.userKeyword}」搜索失败：${error}`
+      : `搜索失败：${error}`;
   } finally {
     if (requestVersion === searchState.requestVersion) {
       searchButton.disabled = false;
@@ -3327,12 +3366,25 @@ window.addEventListener("bilibili-music-viewchange", (event) => {
   if (["favorites", "playlists"].includes(event.detail?.view)) {
     loadLibrary();
   }
+  if (event.detail?.view === "search" && pendingSearchRestore) {
+    const keyword = pendingSearchRestore;
+    pendingSearchRestore = null;
+    if (!searchState.results.length && searchKeyword.value.trim() === keyword) {
+      // 自动恢复不算用户搜索，不计入搜索历史。
+      runSearch({ userKeyword: keyword, recordHistory: false, restored: true });
+    }
+  }
 });
 window.addEventListener("ai-config-updated", refreshAiKeyState);
 
 updateHomeModeUi();
 refreshAiKeyState();
 window.addEventListener("DOMContentLoaded", restorePlaybackState, { once: true });
+const restoreKeyword = readLastSearchKeyword();
+if (restoreKeyword && !searchKeyword.value.trim()) {
+  searchKeyword.value = restoreKeyword;
+  pendingSearchRestore = restoreKeyword;
+}
 loadLibrary();
 updateMusicTabs();
 updateQueueUi();

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -2652,6 +2652,14 @@ svg {
   font-variant-numeric: tabular-nums;
 }
 
+.playlist-choice.is-added span {
+  color: var(--text-3);
+}
+
+.playlist-choice.is-added small {
+  color: var(--text-2);
+}
+
 .library-divider {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## 概述

本 PR 包含两个独立改进：

### 1. 加入歌单弹窗对已包含该曲的歌单给出明确提示（fix）

**问题**：播放中点击"加入歌单"，若该歌单已包含此曲，点击后无任何反馈（后端静默跳过重复项仍返回成功，前端伪装成功提示）。

**修复**：
- 后端 `add_to_playlist` 重复添加时返回 `歌曲已在歌单「X」中` 错误，不再静默跳过，与 `remove_from_playlist` 的错误语义对称；重复路径不写盘
- 前端弹窗内已包含当前歌曲的歌单显示"已添加 · N 首"灰态标记（`aria-disabled`）
- 点击已添加歌单时状态条提示"该歌曲已在歌单「X」中，无需重复加入"，弹窗保持打开

### 2. 重启后进入搜索页自动复用上次搜索关键词（feat）

**需求**：重新打开应用后，搜索页默认展示上一次的搜索结果。

**方案选择——为什么是方案 A（只存关键词、重新搜索，而不是缓存结果快照）**：

> **使用本软件的场景大部分都在有网络的前提下**（B 站音频播放、搜索本身都依赖网络），因此恢复时多发起一次搜索请求是完全可接受的代价。方案 A 换来的好处是：结果永远最新（不存在缓存过期/视频删稿导致的失效条目）、无快照数据结构维护负担、断网场景行为与普通搜索失败一致且提示明确。

**实现**：
- 仅在搜索**真实成功**后把关键词存入 `localStorage`；失败的搜索、BV 直接播放、无关键词的分区热门都不会沉淀
- 启动时回填搜索框；**首次进入搜索页**时才自动发起恢复搜索（懒触发，用户不去搜索页就不浪费请求）
- 搜索全程复用现有 `runSearch` 链路与 `requestVersion` 新旧隔离，不新建状态机、不触碰播放队列（`queueSearchVersion` 保持 null，维持展示/队列解耦）
- 搜索中 / 成功 / 失败状态条均明确提示已复用关键词：如"已复用上次搜索关键词「X」，正在搜索…"；断网失败后关键词留在框中，按 Enter 即可重试
- 自动恢复**不计入搜索历史**（不是用户主动搜索）

## 测试

- Rust 单测 146 通过（新增：重复添加拒绝且不写盘、大小写 BV 视为重复、异曲正常加入）
- 前端 node:test 59 通过（新增 `tests/last-search-restore.test.cjs` 5 用例：复用提示三态、成功才持久化、分区热门不覆盖、坏数据截断）
- macOS 实测通过：搜索 → 重启 → 进搜索页自动恢复关键词并展示结果；重复加入歌单弹窗提示正确
- 未触碰取流链路、播放队列状态机、WBI 签名、路径策略等既有固化逻辑

## 已知取舍

- WKWebView 的 localStorage 惰性落盘：异常退出（崩溃/强杀）可能丢失最后一次关键词；正常关闭窗口为优雅退出不受影响。鉴于关键词价值低、重输成本小，接受此取舍